### PR TITLE
Add libiconv requirement to run on macOS

### DIFF
--- a/.ci_support/linux_c_compilergcc.yaml
+++ b/.ci_support/linux_c_compilergcc.yaml
@@ -7,7 +7,7 @@ channel_sources:
 channel_targets:
 - conda-forge gcc7
 docker_image:
-- conda/c3i-linux-64
+- condaforge/linux-anvil-comp7
 zip_keys:
 - - c_compiler
   - channel_sources

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
 
 build:
-  number: 1003
+  number: 1004
   skip: True  # [win]
   detect_binary_files_with_prefix: True
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
     - automake
   host:
     - libiconv  # [osx]
+  run:
+    - libiconv  # [osx]
 
 test:
   commands:


### PR DESCRIPTION
Not sure if there is something I'm missing here, but it appears that `libiconv` isn't listed at run time. This adds it. Though it would be great if someone could check that this makes sense in case I'm missing something.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
